### PR TITLE
fix compilation error on Ubuntu22

### DIFF
--- a/src/vtkIECTransformLogic.cxx
+++ b/src/vtkIECTransformLogic.cxx
@@ -29,7 +29,7 @@
 #include <vtkTransform.h>
 
 // STD includes
-#include <array>
+#include <algorithm>
 
 //----------------------------------------------------------------------------
 vtkStandardNewMacro(vtkIECTransformLogic);


### PR DESCRIPTION
error: no matching function for call to ‘find(std
and
error: ‘reverse’ is not a member of ‘std’

@cpinter @TrosnyogoSzakoca 