### PR TITLE
FIX: RAS transformation should not be the identity

### DIFF
--- a/src/vtkIECTransformLogic.cxx
+++ b/src/vtkIECTransformLogic.cxx
@@ -109,9 +109,17 @@ vtkIECTransformLogic::vtkIECTransformLogic()
   this->CoordinateSystemsHierarchy[TableTop] = { Patient };
   this->CoordinateSystemsHierarchy[Patient] = { RAS };
 
+  // Build transformations that are not identity by default
+  // RAS is equivalent to rotation around x of -90deg plus rotation around z of 180deg (could be also defined as Identity + 2 Rotate statements)
+  double rasToPatientTransformationMatrix[16] = {-1,0,0,0,
+                                                  0,0,1,0,
+                                                  0,1,0,0,
+                                                  0,0,0,1};
+  this->RasToPatientTransform->Concatenate(rasToPatientTransformationMatrix);
+
   //
   // Build concatenated transform hierarchy
-  // 
+  //
   this->GantryToFixedReferenceConcatenatedTransform->Concatenate(this->FixedReferenceToRasTransform);
   this->GantryToFixedReferenceConcatenatedTransform->Concatenate(this->GantryToFixedReferenceTransform);
 
@@ -120,7 +128,7 @@ vtkIECTransformLogic::vtkIECTransformLogic()
 
   this->WedgeFilterToCollimatorConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
   this->WedgeFilterToCollimatorConcatenatedTransform->Concatenate(this->WedgeFilterToCollimatorTransform);
-    
+
   this->LeftImagingPanelToGantryConcatenatedTransform->Concatenate(this->CollimatorToGantryConcatenatedTransform);
   this->LeftImagingPanelToGantryConcatenatedTransform->Concatenate(this->LeftImagingPanelToGantryTransform);
 
@@ -176,7 +184,7 @@ void vtkIECTransformLogic::PrintSelf(ostream& os, vtkIndent indent)
   os << indent << "TableTopToTableTopEccentricRotationTransform: " << this->TableTopToTableTopEccentricRotationTransform << std::endl;
   os << indent << "PatientToTableTopTransform: " << this->PatientToTableTopTransform << std::endl;
   os << indent << "RasToPatientTransform: " << this->RasToPatientTransform << std::endl;
-  
+
   os << indent << std::endl << "Concatenated transforms:" << std::endl;
   os << indent << "GantryToFixedReferenceConcatenatedTransform: " << this->GantryToFixedReferenceConcatenatedTransform << std::endl;
   os << indent << "CollimatorToGantryConcatenatedTransform: " << this->CollimatorToGantryConcatenatedTransform << std::endl;

--- a/src/vtkIECTransformLogic.h
+++ b/src/vtkIECTransformLogic.h
@@ -47,7 +47,7 @@ class vtkGeneralTransform;
 /// RT beam node to get the geometrical parameters defining the state of the objects involved.
 /// Image describing these coordinate frames:
 /// https://github.com/SlicerRt/SlicerRtDoc/blob/master/technical/IEC%2061217-2002_CoordinateSystemsDiagram_HiRes.png
-///
+/// The RAS coordinate system is not part of IEC but we leave it here as a helper function since it's used e.g. in Slicer https://slicer.readthedocs.io/en/latest/user_guide/coordinate_systems.html
 
 /*
                           "IEC 61217:2011 Hierarchy"


### PR DESCRIPTION
The RAS-to-patient transformation appears to correspond to the identity (which seems incorrect), is there a reason for this or is this implementation change ok?